### PR TITLE
Cancel concurrent deployment workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,14 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
+
+concurrency: 
+  group: deployment
+  cancel-in-progress: true
+
 jobs:
   push_to_registry:
     name: Push Docker image to GitHub Packages


### PR DESCRIPTION
If we merge multiple things near simultaneously, we want to cancel the previous workflow as it's useless